### PR TITLE
Feature/mmi

### DIFF
--- a/mmi.js
+++ b/mmi.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+require('shelljs/global');
+
+if (!which('mongoimport')) {
+  echo('Sorry, this script requires mongoimport');
+  exit(1);
+}
+
+/**
+ * Module dependencies.
+ */
+var child_process = require('child_process');
+var moment = require('moment');
+var Promise = require('bluebird');
+var fs = Promise.promisifyAll(require('fs'));
+var tpl = require('tpl_apply');
+
+var current_path = process.cwd();
+var config_file = current_path + '/mongo.config.json';
+var source = __dirname + '/tpl_mmi.js';
+var dest = process.cwd() + '/import.sh';
+
+console.log('moa mongodb-import');
+
+if (fs.existsSync(config_file) === true) {
+  var latestBackUp = process.argv[2] ? process.argv[2] : getLatestBackup(current_path);
+  var _new_json_string = JSON.parse(JSON.stringify(fs.readFileSync(config_file, {
+    encoding: 'utf-8'
+  })))
+  var config = JSON.parse(_new_json_string);
+
+  generate_shell(config, latestBackUp);
+} else {
+  echo('Sorry, please run this script in a mmb directory');
+  exit(1);
+}
+
+/**
+ * Find the last modified directory's name in a mmb directory
+ *
+ * @param {String} the mmb directory
+ * @return {String}
+ */
+function getLatestBackup(directory) {
+  try {
+    return fs.readdirSync(current_path)
+      .map(function (fileName) {
+        var stat = fs.statSync(current_path + '/' + fileName);
+        if (stat.isDirectory()) {
+          return {
+            name: fileName,
+            stat: stat
+          }
+        }
+      })
+      .filter(function (file) {
+        return file !== undefined;
+      }).reduce(function (preFile, curFile) {
+        if (curFile.stat.mtime > preFile.stat.mtime) {
+          return curFile;
+        } else {
+          return preFile;
+        }
+      }).name;
+  } catch (err) {
+    echo('Sorry, can not find any available directory');
+    exit(1);
+  }
+}
+
+function generate_shell(config, latestBackUp) {
+  var collection_names = fs.readdirSync(current_path + '/' + latestBackUp)
+    .map(function (fileName) {
+      return fileName.split('.')[0];
+    });
+
+  console.log(collection_names);
+
+  tpl.tpl_apply(source, {
+    config: config,
+    collection_names: collection_names
+  }, dest);
+
+  setTimeout(function () {
+    chmod('u+x', dest);
+    // execFile: executes a file with the specified arguments
+    child_process.execFile(dest, [latestBackUp], {
+      cwd: current_path
+    }, function (error, stdout, stderr) {
+      if (error !== null) {
+        console.log('exec error: ' + error);
+      } else {
+        console.log('exec sucess!');
+      }
+    });
+  }, 200)
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "bluebird": "^2.9.34",
     "commander": "^2.8.1",
-    "get_collection_names": "^1.0.2",
+    "get_collection_names": "^1.0.3",
     "moment": "^2.10.6",
     "shelljs": "^0.5.3",
     "tpl_apply": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -11,14 +11,16 @@
   "bin": {
     "mongobackup": "index.js",
     "mb": "index.js",
-    "mmb": "index.js"
+    "mmb": "index.js",
+    "mi": "mmi.js",
+    "mmi": "mmi.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "bluebird": "^2.9.34",
     "commander": "^2.8.1",
-    "get_collection_names": "^1.0.3",
+    "get_collection_names": "^1.0.2",
     "moment": "^2.10.6",
     "shelljs": "^0.5.3",
     "tpl_apply": "^1.0.2"

--- a/tpl_mmi.js
+++ b/tpl_mmi.js
@@ -1,0 +1,7 @@
+#! /bin/bash
+#  ./import.sh 20150828
+echo $@
+
+{{#each collection_names}}
+nohup mongoimport --drop -d {{../config.db}} -c {{this}}  --host {{../config.host}} --port {{../config.port}} $@/{{this}}.csv>> $@_imoport.log
+{{/each}}


### PR DESCRIPTION
1，实现了mmi功能。
2，清空数据操作直接使用了`mongoimport`的`--drop`参数。
3，若未指定导入日期，默认导入最后更改的目录。
4，感觉是一个坑：`tpl_apply_with_register_helper`方法中，`rs`是提供了`encoding`的`fs.createReadStream`方法所创建的流，所以`data`事件得到的`trunk`是字符串。调用`bufferHelper.toBuffer()`后，`bufferHelper`库内部调用`Buffer.concat(this.buffers);`，这时，`this.buffers`其实是个字符串数组，node.js内部其实会认为这个数组中每个元素都是`Buffer`实例，且调用它们的`copy`方法，这时就会报`buf.copy is not a function`。之所以之前没有报错，是因为在`mmb`的情况下，`this.buffers`是一个长度为1的字符串数组，在node.js v.012中，在数组只有一个元素时，直接就把这个元素作为结果返回了（ https://github.com/joyent/node/blob/v0.12.7-release/lib/buffer.js#L209 ）。但在io.js v3.x后，这个`Buffer.concat`方法的实现改变了，不再检查只有一个元素的情况了（ https://github.com/nodejs/node/blob/master/lib/buffer.js#L219 ）。所以在之后的node版本中，应该只要执行`mmb`，必然就会报错（在iojs v3.1下亲测会报错）。
